### PR TITLE
Update dict_array.py

### DIFF
--- a/maniskill2_learn/utils/data/dict_array.py
+++ b/maniskill2_learn/utils/data/dict_array.py
@@ -335,7 +335,7 @@ class GDict:
                 shape = shape[0]
             return shape
 
-        return self._recursive_do_gdict(self.memory, get_shape)
+        return self._recursive_do_on_memory(self.memory, get_shape)
 
     @property
     def list_shape(self):
@@ -347,32 +347,32 @@ class GDict:
                 shape = list(shape)  # For torch.Size
             return shape
 
-        return self._recursive_do_gdict(self.memory, get_shape)
+        return self._recursive_do_on_memory(self.memory, get_shape)
 
     @property
     def type(self):
-        return self._recursive_do_gdict(self.memory, type)
+        return self._recursive_do_on_memory(self.memory, type)
 
     @property
     def dtype(self):
-        return self._recursive_do_gdict(self.memory, get_dtype)
+        return self._recursive_do_on_memory(self.memory, get_dtype)
 
     @property
     def nbytes(self):
-        return self._recursive_do_gdict(self.memory, get_nbytes)
+        return self._recursive_do_on_memory(self.memory, get_nbytes)
 
     @property
     def is_np(self):
-        return self._recursive_do_gdict(self.memory, is_np)
+        return self._recursive_do_on_memory(self.memory, is_np)
 
     @property
     def is_np_all(self):
-        ret = self._flatten(self._recursive_do_gdict(self.memory, is_np, wrapper=False))
+        ret = self._flatten(self._recursive_do_on_memory(self.memory, is_np))
         return np.alltrue([v for k, v in ret.items()]) if isinstance(ret, dict) else ret
 
     @property
     def nbytes_all(self):
-        ret = self._flatten(self._recursive_do_gdict(self.memory, get_nbytes, wrapper=False))
+        ret = self._flatten(self._recursive_do_on_memory(self.memory, get_nbytes))
         return sum([v for k, v in ret.items()]) if isinstance(ret, dict) else ret
 
     @property
@@ -387,7 +387,7 @@ class GDict:
                 device = f"{device.type}:{device.index}" if device.index is not None else f"{device.type}"
             return device
 
-        return self._recursive_do_gdict(self.memory, get_device)
+        return self._recursive_do_on_memory(self.memory, get_device)
 
     def cpu(self, wrapper=True):
         return self._recursive_do_gdict(self.memory, to_cpu, wrapper=wrapper)


### PR DESCRIPTION
A pycharm debugger will loop through each attribute of a class. Before the fix, these properties return a GDict and the GDict has its own set of properties.  As such, I made these changes in my codebase to prevent pycharm debugger from looping in these property queries. A few other references should be changed from GDict.shape.memory to GDict.shape. I hope this helps.